### PR TITLE
update to gnome 43 runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ flatpak install org.zrythm.Zrythm
 This package supports Flatpak builds of LV2, LXVST, and VST3 plugins. Plugins not installed as Flatpak cannot be used.
 
 You can install Plugins using GNOME Software. Or, to view a list of installable plugins, run:
-`flatpak install org.freedesktop.LinuxAudio.Plugins//21.08 -y`
+`flatpak install org.freedesktop.LinuxAudio.Plugins//22.08 -y`
 
 ## JACK Support
 

--- a/org.zrythm.Zrythm.json
+++ b/org.zrythm.Zrythm.json
@@ -548,42 +548,15 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://gitlab.gnome.org/chergert/libpanel",
-                    "commit": "11a83c39014254540015999a262f41a4e0fc7579",
-                    "//": "TODO add x-checker-data when bump to 43 runtime"
-                }
-            ]
-        },
-        {
-            "name": "libadwaita",
-            "buildsystem": "meson",
-            "build-options": {
-                "no-debuginfo": true
-            },
-            "config-opts": [
-                "-Dintrospection=disabled",
-                "-Dgtk_doc=false",
-                "-Dtests=false",
-                "-Dexamples=false",
-                "-Dvapi=false"
-            ],
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://gitlab.gnome.org/GNOME/libadwaita",
-                    "commit": "7387b453a4c93fbb60d68ec009af6f719fe8bab9",
-                    "tag": "1.2.beta",
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/libpanel/1.0/libpanel-1.0.alpha.tar.xz",
+                    "sha256": "370b39bf544c65ff732927817ede337cb8a15aa36d7081cdb91b593c040d3195",
                     "x-checker-data": {
                         "type": "gnome",
-                        "name": "libadwaita",
-                        "stable-only": false
+                        "name": "libpanel",
+                        "stable-only": true
                     }
                 }
-            ],
-            "cleanup": [
-                "/include",
-                "/lib/pkgconfig"
             ]
         },
         {

--- a/org.zrythm.Zrythm.json
+++ b/org.zrythm.Zrythm.json
@@ -1,7 +1,7 @@
 {
     "id": "org.zrythm.Zrythm",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "42",
+    "runtime-version": "43",
     "sdk": "org.gnome.Sdk",
     "command": "zrythm_launch",
     "rename-icon": "zrythm",
@@ -19,7 +19,7 @@
     "add-extensions": {
         "org.freedesktop.LinuxAudio.Plugins": {
             "directory": "extensions/Plugins",
-            "version": "21.08",
+            "version": "22.08",
             "add-ld-path": "lib",
             "merge-dirs": "ladspa;dssi;lv2;vst;vst3",
             "subdirectories": true,


### PR DESCRIPTION
should resolve jack-pipewire bug which leads to a crash