### PR TITLE
build gtk and libadwaita from source

### DIFF
--- a/org.zrythm.Zrythm.json
+++ b/org.zrythm.Zrythm.json
@@ -546,6 +546,13 @@
         {
             "name": "gtk",
             "buildsystem": "meson",
+            "config-opts": [
+                "-Dbuild-demos=false",
+                "-Ddemos=false",
+                "-Dbuild-testsuite=false",
+                "-Dbuild-examples=false",
+                "-Dbuild-tests=false"
+            ],
             "sources": [
                 {
                     "type": "git",
@@ -565,8 +572,10 @@
             "name": "libadwaita",
             "buildsystem": "meson",
             "config-opts": [
-                "-Dexamples=false",
-                "-Dtests=false"
+                "-Dvapi=false",
+                "-Dgtk_doc=false",
+                "-Dtests=false",
+                "-Dexamples=false"
             ],
             "sources": [
                 {

--- a/org.zrythm.Zrythm.json
+++ b/org.zrythm.Zrythm.json
@@ -40,11 +40,19 @@
     "modules": [
                 {
             "name": "gtk",
+            "buildsystem": "meson",
             "sources": [
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/gtk.git",
-                    "branch": "main"
+                    "commit": "965b3025d97fcc3682b861e32b01c5fdcc684e31",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://gitlab.gnome.org/api/v4/projects/gnome%2Fgtk/repository/commits/main",
+                        "commit-query": ".id",
+                        "version-query": ".short_id",
+                        "timestamp-query": ".committed_date"
+                    }
                 }
             ]
         },
@@ -59,7 +67,14 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/libadwaita.git",
-                    "branch": "main"
+                    "commit": "1c2b09bbe12737fd2b107e0816a5b4f57cfc4a16",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://gitlab.gnome.org/api/v4/projects/gnome%2Flibadwaita/repository/commits/main",
+                        "commit-query": ".id",
+                        "version-query": ".short_id",
+                        "timestamp-query": ".committed_date"
+                    }
                 }
             ]
         },

--- a/org.zrythm.Zrythm.json
+++ b/org.zrythm.Zrythm.json
@@ -38,46 +38,6 @@
         "*.a"
     ],
     "modules": [
-                {
-            "name": "gtk",
-            "buildsystem": "meson",
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://gitlab.gnome.org/GNOME/gtk.git",
-                    "commit": "965b3025d97fcc3682b861e32b01c5fdcc684e31",
-                    "x-checker-data": {
-                        "type": "json",
-                        "url": "https://gitlab.gnome.org/api/v4/projects/gnome%2Fgtk/repository/commits/main",
-                        "commit-query": ".id",
-                        "version-query": ".short_id",
-                        "timestamp-query": ".committed_date"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "libadwaita",
-            "buildsystem": "meson",
-            "config-opts": [
-                "-Dexamples=false",
-                "-Dtests=false"
-            ],
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://gitlab.gnome.org/GNOME/libadwaita.git",
-                    "commit": "1c2b09bbe12737fd2b107e0816a5b4f57cfc4a16",
-                    "x-checker-data": {
-                        "type": "json",
-                        "url": "https://gitlab.gnome.org/api/v4/projects/gnome%2Flibadwaita/repository/commits/main",
-                        "commit-query": ".id",
-                        "version-query": ".short_id",
-                        "timestamp-query": ".committed_date"
-                    }
-                }
-            ]
-        },
         {
             "name": "vamp-plugin-sdk",
             "buildsystem": "autotools",
@@ -576,6 +536,46 @@
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://gitlab.com/api/v4/projects/drobilla%2Fzix/repository/commits/main",
+                        "commit-query": ".id",
+                        "version-query": ".short_id",
+                        "timestamp-query": ".committed_date"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "gtk",
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://gitlab.gnome.org/GNOME/gtk.git",
+                    "commit": "965b3025d97fcc3682b861e32b01c5fdcc684e31",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://gitlab.gnome.org/api/v4/projects/gnome%2Fgtk/repository/commits/main",
+                        "commit-query": ".id",
+                        "version-query": ".short_id",
+                        "timestamp-query": ".committed_date"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "libadwaita",
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Dexamples=false",
+                "-Dtests=false"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://gitlab.gnome.org/GNOME/libadwaita.git",
+                    "commit": "1c2b09bbe12737fd2b107e0816a5b4f57cfc4a16",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://gitlab.gnome.org/api/v4/projects/gnome%2Flibadwaita/repository/commits/main",
                         "commit-query": ".id",
                         "version-query": ".short_id",
                         "timestamp-query": ".committed_date"

--- a/org.zrythm.Zrythm.json
+++ b/org.zrythm.Zrythm.json
@@ -38,6 +38,31 @@
         "*.a"
     ],
     "modules": [
+                {
+            "name": "gtk",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://gitlab.gnome.org/GNOME/gtk.git",
+                    "branch": "main"
+                }
+            ]
+        },
+        {
+            "name": "libadwaita",
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Dexamples=false",
+                "-Dtests=false"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://gitlab.gnome.org/GNOME/libadwaita.git",
+                    "branch": "main"
+                }
+            ]
+        },
         {
             "name": "vamp-plugin-sdk",
             "buildsystem": "autotools",

--- a/org.zrythm.Zrythm.json
+++ b/org.zrythm.Zrythm.json
@@ -590,6 +590,52 @@
                         "timestamp-query": ".committed_date"
                     }
                 }
+            ],
+            "modules": [
+                {
+                    "name": "appstream",
+                    "buildsystem": "meson",
+                    "config-opts": [
+                        "-Dstemming=false",
+                        "-Dapidocs=false"
+                    ],
+                    "sources": [
+                        {
+                            "type": "archive",
+                            "url": "https://github.com/ximion/appstream/archive/refs/tags/v0.16.2.tar.gz",
+                            "sha256": "9a2ebe660704878ab795470a72cd53049408ddd9da6e9cb45232cf0ed6505660",
+                            "x-checker-data": {
+                                "type": "anitya",
+                                "project-id": 10385,
+                                "url-template": "https://github.com/ximion/appstream/archive/refs/tags/v$version.tar.gz"
+                            }
+                        }
+                    ],
+                    "modules": [
+                        {
+                            "name": "libxmlb",
+                            "buildsystem": "meson",
+                            "config-opts": [
+                                "-Dgtkdoc=false"
+                            ],
+                            "sources": [
+                                {
+                                    "type": "git",
+                                    "url": "https://github.com/hughsie/libxmlb",
+                                    "commit": "3be2235c9be79c0ece789d3d50c52c15be31829d",
+                                    "tag": "0.3.13",
+                                    "x-checker-data": {
+                                        "type": "json",
+                                        "url": "https://api.github.com/repos/hughsie/libxmlb/releases/latest",
+                                        "tag-query": ".tag_name",
+                                        "version-query": "$tag | sub(\"^jq-\"; \"\")",
+                                        "timestamp-query": ".published_at"
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
             ]
         },
         {


### PR DESCRIPTION
this is my first attempt at making latest gtk available to zrythm, independent of the version given by the gnome runtime.  
Because gtk is evolving at such a quick pace, its main branch includes important bug fixes and features which are not yet present in any release, needless to speak about the runtime. Some of these bug fixes are accessibility related, which I consider very important and therefore should be fixed in as many apps as possible.