### PR TITLE
revert cyaml version change (causes error on startup)

### DIFF
--- a/org.zrythm.Zrythm.json
+++ b/org.zrythm.Zrythm.json
@@ -232,8 +232,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/tlsa/libcyaml",
-                    "commit": "e2bea44c472719daff095541b22b038fa54c274b",
-                    "tag": "v1.4.1",
+                    "commit": "0f25b41812083b095a1a79839e0cc07413eabbe4",
+                    "tag": "v1.4.0",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/tlsa/libcyaml/releases/latest",


### PR DESCRIPTION
(as asked inn #flatpak:matrix.org):

one of my dependencies does this during make install:
```
install -c build/release/libcyaml.so.1 /app/lib/libcyaml.so.1.4.0
(cd /app/lib && { ln -s -f libcyaml.so.1.4.0 libcyaml.so.1 || { rm -f libcyaml.so.1 && ln -s libcyaml.so.1.4.0 libcyaml.so.1; }; })
(cd /app/lib && { ln -s -f libcyaml.so.1.4.0 libcyaml.so || { rm -f libcyaml.so && ln -s libcyaml.so.1.4.0 libcyaml.so; }; })
```
and then the flathub job builder removes the original library during "Cleaning up":
```
Removing files/lib/libcyaml.so.1.4.0
Removing files/lib/libcyaml.a
```
so the flatpak won't run:
```
/app/bin/zrythm: error while loading shared libraries: libcyaml.so.1: cannot open shared object file: No such file or directory
```

any ideas what's wrong? here's the manifest:
https://github.com/flathub/org.zrythm.Zrythm/blob/master/org.zrythm.Zrythm.json
and the build log:
https://buildbot.flathub.org/#/builders/35/builds/7360