### PR TITLE
removed host access

### DIFF
--- a/org.zrythm.Zrythm.json
+++ b/org.zrythm.Zrythm.json
@@ -12,7 +12,12 @@
         "--share=network",
         "--socket=pulseaudio",
         "--device=all",
-        "--filesystem=host:ro",
+        "--filesystem=home:ro",
+        "--filesystem=/media:ro",
+        "--filesystem=/mnt:ro",
+        "--filesystem=/run/media:ro",
+        "--filesystem=/var/run/media:ro",
+        "--filesystem=/var/mnt:ro",
         "--filesystem=xdg-run/pipewire-0",
         "--system-talk-name=org.freedesktop.RealtimeKit1"
     ],


### PR DESCRIPTION
Not sure what you wanted to accomplish with host:ro, does it not need any writing access at all?

Anyways, I think having only media locations would make it at least a bit more transparent. Users than also can easily disable locations.