### PR TITLE
fix zrythm x-checker-data

### DIFF
--- a/org.zrythm.Zrythm.json
+++ b/org.zrythm.Zrythm.json
@@ -635,8 +635,11 @@
                     "tag": "v1.0.0",
                     "x-checker-data": {
                         "is-important": true,
-                        "type": "git",
-                        "tag-pattern": "^v(.*[\\d.]+)$"
+                        "type": "json",
+                        "url": "https://api.github.com/repos/zrythm/zrythm/releases/latest",
+                        "tag-query": ".tag_name",
+                        "version-query": "$tag | sub(\"^jq-\"; \"\")",
+                        "timestamp-query": ".published_at"
                     }
                 },
                 {


### PR DESCRIPTION
Switch to using github api to get latest git tag, so we can properly skip pre releases since they are explicitly labeled.